### PR TITLE
kaitou のバグ修正とテストの追加

### DIFF
--- a/src/kaitou.rs
+++ b/src/kaitou.rs
@@ -52,7 +52,7 @@ fn case1() {
 
     let grid = Grid::new(12, 2);
 
-    let expected = "01230320111103230210\r\n1\r\nA0\r\n3\r\nUDLR".to_owned();
+    let expected = "01230320111103230210\r\n1\r\nA1\r\n4\r\nUDLR\r\n".to_owned();
     let actual = ans(
         &[Operation {
             select: grid.pos(10, 1),


### PR DESCRIPTION
修正内容:
- 座標の出力を 16 進数になるように修正
- 改行文字のエスケープシーケンスを修正
- いくつかの `format!` を `to_string` に置き換え
